### PR TITLE
Tau.feat.pr03.ghi 005

### DIFF
--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -247,7 +247,7 @@ sub GetOptionsFromArray {
                         die "Missing required option $osname\n";
                     }
                 } else {
-                    warn  "Can't enforce 'required' status without also knowing the 'handler' for option '$osname'. "
+                    die "Can't enforce 'required' status without also knowing the 'handler' for option '$osname'. "
                         . "You need to provide a 'handler' to optspec() in order to benefit from that feature\n";
                 }
             }
@@ -269,7 +269,7 @@ sub GetOptionsFromArray {
                         $_->{handler} = { %{ $_->{default} } }; # shallow copy
                     }
                 } else {
-                    warn  "Can't enforce 'required' status without also knowing the 'handler' for option '$osname'. "
+                    die "Can't enforce 'required' status without also knowing the 'handler' for option '$osname'. "
                         . "You need to provide a 'handler' to optspec() in order to benefit from that feature\n";
                 }
             }

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -226,6 +226,23 @@ subtest "optspec: invalid extra properties -> dies" => sub {
         expected_argv => [qw//],
     );
 }
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: evaporates when it has no handler (hash-storage mode)',
+        opts_spec => [
+          $opts,
+          'foo=s', optspec(),
+          'bar=s',
+          'baz=s', optspec(handler => \$opts->{baz} ),
+          'gaz=s', \$opts->{gaz},
+        ],
+        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
+        opts => $opts,
+        expected_opts => {foo => "boo", bar => "bur", baz => "boz", gaz => "gez" },
+        expected_argv => [qw//],
+    );
+}
 
 # XXX test summary
 # XXX test pod

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -243,22 +243,6 @@ subtest "optspec: invalid extra properties -> dies" => sub {
         expected_argv => [qw//],
     );
 }
-TODO: { # TABULO[N]: I se why this test doesn't work as expected; because of the 'eval' in test_getoptions()
-  # But, it's probably best to just delete this test anyhow, as it's something GoL can and should decide on its own.
- local TODO = "Disabled until the test case itself is corrected or better yet, deleted. ";
- subtest "optspec: Make sure GoL itself catches the case where '<>' has no effective handler" => sub {
-      my $opts = {};
-      test_getoptions(
-          name => 'optspec: See if GoL catches this utmost nonsense and then dies',
-          opts_spec => [
-            '<>', optspec(),
-          ],
-          argv => [],
-          opts => $opts,
-      );
-   };
- };
-}
 {
     our $opt_foo;
     my $opts = {};


### PR DESCRIPTION
Hi Perlancar,

Thanks a lot for making the time for these PR's, which probably have distracted whatever you had expected to have been doing.

This PR hopefully resolves #5, adopting the behaviour we have disscussed and agreed upon on fringe comments for an other issue, (https://github.com/perlancar/perl-Getopt-Long-More/issues/1#issuecomment-455994018) earlier today.

I am finally going ahead and submitting those changes in an "optimistic" expectation, based upon the  evolution of that thread, even though I haven't heard your final feedback on the commit that I had made available for your review in that midst.

As you will notice, this submitted PR adds a 3rd commit, which carries very slight changes to the version that was out for review, namely: 

  - 1)  `More.pm` now prefers to `die` rather than `warn` when faced with a situation where it cannot possibly honor a validation constraint that it encounters for an `OptSpec` that lacks a `handler`, which may be sumarized to the following condition (although the actual code is scattered):

    die if  !exists $_->{handler} && ( $_->{required}  || exists $_->{default} )` 

  _(BTW, I should have added a couple tests in there that ensure the above described behaviour, but somehow I could not manage to make that happen)_ **Perhaps you could code those, or briefly explain how I could go about it, either now or later?**

  - 2)  I have now removed the -uncessary- attempt for a test that tried (unsuccesfully) to ensure GoL was dies with `Getopts (<> => optspec() )`.

Also, please acknowledge that you you have taken note of the **new bug** that is, for now, hastily signaled in the fringe comments of the test suite. I am preparing an proper issue for it that will be entitled something like `Avoid inadvertently hijacking GoL's legacy "default destinations" `.

That's it for now. 

Let me know if anything in the submitted PR raises an eyebrow or comes as a surprise (I don't see any reason, based on my understanding of our discussion, but you never know).

Cheers!

-----------

### N.B. : 

One last thing: In the general case, I do fully agree with your remarks about early failure, and to a lesser extent, the docs. 

However, in this particular case, I also have something else in mind ... in addition to to your parenthetical observation, which is probablly already sufficient to label this as something "that could be stretched to go either way", dpending on what else is at stake, .. (more on this later, if you wish).






