### PR TITLE
Fix #9 - Avoid hijacking GoL legacy default dests

### DIFF
--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -38,7 +38,7 @@ sub GetOptionsFromString(@) {
     my ($string) = shift;
     require Text::ParseWords;
     my $args = [ Text::ParseWords::shellwords($string) ];
-    my $caller ||= (caller)[0];	# current context
+    local $Getopt::Long::caller ||= (caller)[0];
     my $ret = GetOptionsFromArray($args, @_);
     return ( $ret, $args ) if wantarray;
     if ( @$args ) {
@@ -62,6 +62,8 @@ sub GetOptionsFromArray {
     require Getopt::Long;
 
     my $ary = shift;
+
+    local $Getopt::Long::caller ||= (caller)[0];  # grab and set this asap.
 
     my @go_opts_spec;
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -324,12 +324,8 @@ TODO: {
     );
 }
 {
-    our $opt_foo;   # ==> Expected default destination for option 'foo' (when using GoL's "legacy" call style, as below)
-                    # Currently, the option value silently ends up in '$Getopt::Long::More::opt_foo' :-)
-                    # This is because GoL will create it in its caller's package; which in our case is GLM (since it wraps GoL)...
-                    # This is a new GLM bug for which no github issue exists yet. Hence this comment.
-                    # BTW, resolving this bug would allow us to "use warnings" within GLM, if desired.
-    test_getoptions(  #
+    our $opt_foo;      # ==> Expected default destination for option 'foo' (when using GoL's "legacy" call style, as below)
+    test_getoptions(
         name => 'legacy: can tolerate "default destinations" [1]',  # OK.
         opts_spec => [
           'foo=s',
@@ -340,15 +336,15 @@ TODO: {
         expected_opts => {},
         expected_argv => [qw//],
     );
-    TODO: {
-      local $TODO = "GoL's -legacy- 'default destinations' silently end up in GLM::* package space. [Not yet captured in a gh issue.]";
+    {
+      # DONE: Now passes, suggesting #9 is resolved.
       is($opt_foo // "[undef]" => 'boo', "legacy: default destinations' work as expected" );
     }
 }
 {   our ($opt_foo, $opt_bar);
     my $opts = {};
     test_getoptions(
-        name => "optspec: evaporates when it has no handler in classic (NOT 'hash-storage') mode with 'legacy default desinations'" ,
+        name => "optspec: evaporates when it has no handler in 'classic mode' with 'legacy default desinations'" ,
         opts_spec => [
           'foo=s', optspec(),
           'bar=s',
@@ -361,9 +357,9 @@ TODO: {
         expected_argv => [qw//],
     );
     TODO: {
-      local $TODO = "GoL's legacy 'default destinations' silently end up in GLM::* package space. [Not yet captured in a gh issue.]";
+      # DONE: Now passes, suggesting #9 is resolved.
       is($opt_foo // "[undef]" => 'boo', "optspec: [evaporation][without a handler][in classic mode][legacy default destination][1]");
-      is($opt_bar // "[undef]" => 'bar', "optspec: [evaporation][without a handler][in classic mode][legacy default destination][2]");
+      is($opt_bar // "[undef]" => 'bur', "optspec: [evaporation][without a handler][in classic mode][legacy default destination][2]");
     }
 }
 


### PR DESCRIPTION

This PR resolves #9 - [Avoid hijacking GoL legacy default dests].

It was much easier than initially feared: 2 lines :-)

Because, as turns out, there was an existing GoL mechanism (`$Getopt::Long::caller`).

-----

In addition to the resolving #9, this change should also benefit: 

  - scenarios where GLM itself is wrapped (as long as they follow the same GoL mechanism)
  - when GLM needs to figure out those "default destinations"  (just like it should be able to do for hash storage)  -- touching upon our earlier discussion.

----------
Afaics, the only potential concern with the approach taken by this change is the word "invisible" below : 

````perl

package Getopt::Long;
...
# Official invisible variables.
use vars qw($genprefix $caller $gnu_compat $auto_help $auto_version $longprefix);
...

````

But in any case, GLM already makes use of at least two other _invisible_ variables in there ( `$auto_help` and `$auto_version`), why not another?  -- especially if it is marked "# Official", right?  :-)
 

