### PR TITLE
Tau.feat.ghi 021  deprecate handler  in favor of destination

### DIFF
--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -516,8 +516,11 @@ name-property value pairs:
      ...
  )
 
-All properties are optional. The C<destination> property, if present, will be passed to
-Getopt::Long when parsing options.
+All properties are optional.
+
+=head2 destination =>  ScalarRef / ArrayRef / HashRef /  CodeRef
+
+The C<destination> property, if present, will be passed to Getopt::Long when parsing options.
 
 Note that, in previous versions of this module, C<destination> was referred to as C<handler>,
 which is now B<deprecated>. At this time C<handler> is still being accepted as an

--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -77,10 +77,10 @@ sub GetOptionsFromArray {
     my @opts_spec = @_;
 
     # provide explicit --help|?, for completion. also, we need to override the
-    # option handler to use our HelpMessage.
+    # option destination to use our HelpMessage.
     if ($Getopt::Long::auto_help) {
         unshift @opts_spec, 'help|?' => optspec(
-            handler => sub { HelpMessage() },
+            destination => sub { HelpMessage() },
             summary => 'Print help message and exit',
         );
     }
@@ -89,7 +89,7 @@ sub GetOptionsFromArray {
     # provide explicit --version, for completion
     if ($Getopt::Long::auto_version) {
         unshift @opts_spec, 'version' => optspec(
-            handler => sub { VersionMessage() },
+            destination => sub { VersionMessage() },
             summary => 'Print program version and exit',
         );
     }
@@ -102,23 +102,23 @@ sub GetOptionsFromArray {
     my $prev;
     my $has_arg_handler;
     my $arg_handler_accessed;
-  MAPPING:  # Resulting in the complete EVAPORATION of OptSpec objects, replaced by their handler, if one exists.
+  MAPPING:  # Resulting in the complete EVAPORATION of OptSpec objects, replaced by their destination, if one exists.
       for my $e (@opts_spec) {
         unless ( ref($e) eq 'Getopt::Long::More::OptSpec' ) {
           push @go_opts_spec, $e;
           next;
         }
 
-        next unless exists $e->{handler};
+        next unless exists $e->{destination};
 
         if ( $prev  eq '<>' ) {
           $has_arg_handler++;
           push @go_opts_spec, sub {
             $arg_handler_accessed++;
-            $e->{handler}->(@_);
+            $e->{destination}->(@_);
           };
         } else {
-          push @go_opts_spec, $e->{handler};
+          push @go_opts_spec, $e->{destination};
         }
     } continue {
       $prev = $e;
@@ -235,44 +235,44 @@ sub GetOptionsFromArray {
                             die "Missing required command-line argument\n";
                         }
                     }
-                } elsif ( exists $_->{handler} ) {
-                    if (ref($_->{handler}) eq 'SCALAR'
-                            && !defined(${$_->{handler}})) {
+                } elsif ( exists $_->{destination} ) {
+                    if (ref($_->{destination}) eq 'SCALAR'
+                            && !defined(${$_->{destination}})) {
                         die "Missing required option $osname\n";
                         # XXX doesn't work yet?
-                    } elsif (ref($_->{handler}) eq 'ARRAY' &&
-                                 !@{$_->{handler}}) {
+                    } elsif (ref($_->{destination}) eq 'ARRAY' &&
+                                 !@{$_->{destination}}) {
                         die "Missing required option $osname\n";
                         # XXX doesn't work yet?
-                    } elsif (ref($_->{handler}) eq 'HASH'
-                                 && !keys(%{$_->{handler}})) {
+                    } elsif (ref($_->{destination}) eq 'HASH'
+                                 && !keys(%{$_->{destination}})) {
                         die "Missing required option $osname\n";
                     }
                 } else {
-                    die "Can't enforce 'required' status without also knowing the 'handler' for option '$osname'. "
-                        . "You need to provide a 'handler' to optspec() in order to benefit from that feature\n";
+                    die "Can't enforce 'required' status without also knowing the 'destination' for option '$osname'. "
+                        . "You need to provide a 'destination' to optspec() in order to benefit from that feature\n";
                 }
             }
             # supply default value
             if (defined $_->{default}) {
                 if ($osname eq '<>') {
                     # currently ignored
-                } elsif ( exists $_->{handler} ) {
-                    if (ref($_->{handler}) eq 'SCALAR'
-                            && !defined(${$_->{handler}})) {
-                        ${$_->{handler}} = $_->{default};
+                } elsif ( exists $_->{destination} ) {
+                    if (ref($_->{destination}) eq 'SCALAR'
+                            && !defined(${$_->{destination}})) {
+                        ${$_->{destination}} = $_->{default};
                         # XXX doesn't work yet?
-                    } elsif (ref($_->{handler}) eq 'ARRAY' &&
-                                 !@{$_->{handler}}) {
-                        $_->{handler} = [@{ $_->{default} }]; # shallow copy
+                    } elsif (ref($_->{destination}) eq 'ARRAY' &&
+                                 !@{$_->{destination}}) {
+                        $_->{destination} = [@{ $_->{default} }]; # shallow copy
                         # XXX doesn't work yet?
-                    } elsif (ref($_->{handler}) eq 'HASH' &&
-                                 !keys(%{$_->{handler}})) {
-                        $_->{handler} = { %{ $_->{default} } }; # shallow copy
+                    } elsif (ref($_->{destination}) eq 'HASH' &&
+                                 !keys(%{$_->{destination}})) {
+                        $_->{destination} = { %{ $_->{default} } }; # shallow copy
                     }
                 } else {
-                    die "Can't assign 'default' without also knowing the 'handler' for option '$osname'. "
-                        . "You need to provide a 'handler' to optspec() in order to benefit from that feature\n";
+                    die "Can't assign 'default' without also knowing the 'destination' for option '$osname'. "
+                        . "You need to provide a 'destination' to optspec() in order to benefit from that feature\n";
                 }
             }
         }
@@ -367,18 +367,67 @@ sub OptionsPod {
 }
 
 package # hide from PAUSE indexer
+    Getopt::Long::More::Util;
+
+our @CARP_NOT = qw( Getopt::Long::More Getopt::Long::More::Util  Getopt::Long::More::OptSpec);
+
+# The subroutines here (::Util) are intended to be pretty generic
+# and so could also be used elsewhere later on.
+
+sub map_args {
+  my %o = %{; shift || {} };  # shallow copy
+  my %p = (@_);
+  my ($deprecated, $aliases,
+      $deprecated_aliases) =  map {; $_ || {} } @p{qw/deprecated aliases deprecated_aliases/};
+
+  my %deprecations =  ( %$deprecated, %$deprecated_aliases );
+  my %synonyms     =  ( %$aliases,    %$deprecated_aliases );
+
+  # Deprecated => warn
+  while ( my ($k, $canon) = each %deprecations )  {
+    next unless exists $o{$k};
+    require Carp;
+    Carp::carp( "'$k' is deprecated!",
+                ( defined($canon) ? " You should use '$canon' instead." : () ),
+                "\n"
+              );
+  }
+
+  # Synonym => map to canonical key.
+  while ( my ($k, $canon) = each %synonyms ) {
+    next unless exists $o{$k};
+
+    my $v = delete $o{$k};
+    next unless defined $canon; #  if $canon key is undefined => disregard
+
+    if  ( exists $o{$canon} ) {
+      require Carp;
+      Carp::croak( "'$k' may only be used as a synonym for '$canon'; not alongside it.", "\n" );
+    }
+
+    $o{$canon} = $v;
+  }
+  wantarray ? (%o) : \%o;
+}
+
+
+package # hide from PAUSE indexer
     Getopt::Long::More::OptSpec;
+
+# Poor man's import....
+*map_args = \&Getopt::Long::More::Util::map_args;
 
 sub new {
     my $class = shift;
-    my $obj = bless {@_}, $class;
+    my $obj   = map_args( { @_ }, deprecated_aliases => { handler => 'destination' } );
+
     for (keys %$obj) {
         next if /\A(x|x\..+|_.*)\z/;
-        unless (/\A(handler|required|default|summary|description|completion)\z/) {
+        unless (/\A(required|default|summary|description|destination|completion)\z/) {
             die "Unknown optspec property '$_'";
         }
     }
-    $obj;
+    bless $obj, $class;
 }
 
 1;
@@ -401,7 +450,7 @@ sub new {
      # but if you want to specify extra stuffs...
      'baz'   => optspec(
          # will be passed to Getopt::Long
-         handler => \$opts{baz},
+         destination => \$opts{baz},
 
          # specify that this option is required
          required => 1,
@@ -447,27 +496,35 @@ provides the same interface as Getopt::Long and, unlike other wrappers like
 L<Getopt::Long::Complete> or L<Getopt::Long::Modern> it does not change default
 configuration and all Getopt::Long configuration are supported. In fact,
 Getopt::Long::More behaves much like Getopt::Long until you start to use optspec
-object as one or more option handlers.
+object as one or more option destinations.
 
 
 =head1 OPTSPEC OBJECT
 
 In addition to using scalarref, arrayref, hashref, or coderef as the option
-handler ("linkage") as Getopt::Long allows, Getopt::Long::More also allows using
-optspec object as the linkage. This allows you to specify more stuffs. Optspec
-object is created using the C<optspec> function which accepts a list of property
+destination as Getopt::Long allows, Getopt::Long::More also allows using
+optspec object as the destination. This enables you to specify more stuffs.
+
+Optspec object is created using the C<optspec> function which accepts a list of property
 name-property value pairs:
 
  '--fruit=s' => optspec(
-     handler => \$opts{fruit},
+     destination => \$opts{fruit},
      default => 'apple',
      summary => 'Supply name of fruit to order',
      completion => [qw/apple apricot banana/],
      ...
  )
 
-All properties are optional. Tthe C<handler> property will be passed to
-Getopt::Long when parsing options. In addition to that, these other properties
+All properties are optional. The C<destination> property, if present, will be passed to
+Getopt::Long when parsing options.
+
+Note that, in previous versions of this module, C<destination> was referred to as C<handler>,
+which is now B<deprecated>. At this time C<handler> is still being accepted as an
+I<alias> for C<destination>, but do NOT count on that forever.
+The name C<handler> will be discontinued at one point. You have been B<warned>.
+
+In addition to C<destination>, these other properties
 are also recognized:
 
 =head2 required => bool
@@ -593,7 +650,7 @@ Use the option spec C<< <> >>:
  GetOptions(
      ...
      '<>' => optspec(
-         handler => \&process,
+         destination => \&process,
          completion => sub {
              ...
          },

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -3,10 +3,8 @@
 use strict;
 use warnings;
 use Test::Exception;
+use Test::Warn;
 use Test::More 0.98;
-
-# TABULON: ':no_end_test' for now, because existing tests don't account for warnings.
-use Test::Warnings  qw(:no_end_test);
 
 use Getopt::Long::More qw(optspec);
 
@@ -73,16 +71,15 @@ subtest "optspec: unknown property -> dies" => sub {
 
 
 subtest "optspec: 'handler' is deprecated -> lives, but warns" => sub {
-    # This looks a bit cleaner (than doing by hand), but brings a dependency on Test::Warnings.
-    my @warnings = Test::Warnings::warnings( sub {;
-      lives_ok {; optspec( handler => sub {; } ) }
-    });
-    my $warns = grep { qr/\Whandler\W.*deprecated/ } @warnings;
-    ok ($warns, "optspec: 'handler' is deprecated -> warns");
+    warnings_exist {
+      lives_ok { optspec( handler => sub { } ) }
+    }
+    [qr/\Whandler\W.*deprecated/],
+    "optspec: 'handler' is deprecated -> warns";
 };
 
 subtest "optspec: Illegal to provide both 'destination' and its deprecated alias 'handler' -> dies" => sub {
-    local *STDERR = \*STDOUT; # supress the depecation warning that occurs before 'die' => Just prettier test output.
+    local *STDERR = \*STDOUT; # supress the depecation warning before 'die' => Just prettier test output.
     dies_ok { optspec(destination => sub {}, handler => sub {} ) };
 };
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -67,18 +67,18 @@ subtest "optspec: unknown property -> dies" => sub {
 };
 
 subtest "optspec: extra properties allowed" => sub {
-    lives_ok { optspec(handler=>sub{}, _foo=>1, 'x.bar'=>2, _=>{baz=>3}, x=>{qux=>4}) };
+    lives_ok { optspec(destination=>sub{}, _foo=>1, 'x.bar'=>2, _=>{baz=>3}, x=>{qux=>4}) };
 };
 
 subtest "optspec: invalid extra properties -> dies" => sub {
-    dies_ok { optspec(handler=>sub{}, 'x.'=>1) };
+    dies_ok { optspec(destination=>sub{}, 'x.'=>1) };
 };
 
 {
     my $opts = {};
     test_getoptions(
         name => 'optspec: default (unset)',
-        opts_spec => ['foo=s' => optspec(handler => \$opts->{foo}, default => "bar")],
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
         argv => [qw//],
         opts => $opts,
         expected_opts => {foo => "bar"},
@@ -89,7 +89,7 @@ subtest "optspec: invalid extra properties -> dies" => sub {
     my $opts = {};
     test_getoptions(
         name => 'optspec: default (set)',
-        opts_spec => ['foo=s' => optspec(handler => \$opts->{foo}, default => "bar")],
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
         argv => [qw/--foo qux/],
         opts => $opts,
         expected_opts => {foo => "qux"},
@@ -99,7 +99,7 @@ subtest "optspec: invalid extra properties -> dies" => sub {
 {
     my $opts = {};
     test_getoptions(
-        name => 'optspec: default (set, but no handler) -> dies',
+        name => 'optspec: default (set, but no destination) -> dies',
         opts_spec => ['foo=s' => optspec(default => "bar")],
         argv => [qw/--foo qux/],
         opts => $opts,
@@ -107,10 +107,10 @@ subtest "optspec: invalid extra properties -> dies" => sub {
     );
 }
 TODO: {
-    local $TODO = "currently dies, but we shouldn't require handler when in hash-storage mode";
+    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
     my $opts = {};
     test_getoptions(
-        name => 'optspec: default (set, but no handler) -> dies',
+        name => 'optspec: default (set, but no destination) -> dies',
         opts_spec => [$opts, 'foo=s' => optspec(default => "bar")],
         argv => [qw/--foo qux/],
         opts => $opts,
@@ -122,7 +122,7 @@ TODO: {
     my $opts = {};
     test_getoptions(
         name => 'optspec: default (on <> -> ignored)',
-        opts_spec => ['<>' => optspec(handler => sub{}, default => ["a","b"])],
+        opts_spec => ['<>' => optspec(destination => sub{}, default => ["a","b"])],
         argv => [qw//],
         opts => $opts,
         expected_opts => {},
@@ -134,7 +134,7 @@ TODO: {
     my $opts = {};
     test_getoptions(
         name => 'optspec: required (unset)',
-        opts_spec => ['foo=s' => optspec(handler => \$opts->{foo}, required => 1)],
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
         argv => [qw//],
         dies => 1,
     );
@@ -143,7 +143,7 @@ TODO: {
     my $opts = {};
     test_getoptions(
         name => 'optspec: required (set)',
-        opts_spec => ['foo=s' => optspec(handler => \$opts->{foo}, required => 1)],
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
         argv => [qw/--foo=bar/],
         opts => $opts,
         expected_opts => {foo => "bar"},
@@ -153,7 +153,7 @@ TODO: {
 {
     my $opts = {};
     test_getoptions(
-        name => 'optspec: required (set, but no handler) -> dies',
+        name => 'optspec: required (set, but no destination) -> dies',
         opts_spec => ['foo=s' => optspec(required => 1)],
         argv => [qw/--foo qux/],
         opts => $opts,
@@ -161,10 +161,10 @@ TODO: {
     );
 }
 TODO: {
-    local $TODO = "currently dies, but we shouldn't require handler when in hash-storage mode";
+    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
     my $opts = {};
     test_getoptions(
-        name => 'optspec: required (set, but no handler) -> dies',
+        name => 'optspec: required (set, but no destination) -> dies',
         opts_spec => [$opts, 'foo=s' => optspec(required => 1)],
         argv => [qw/--foo qux/],
         opts => $opts,
@@ -176,7 +176,7 @@ TODO: {
     my $opts = {};
     test_getoptions(
         name => 'optspec: required (on <>, unset)',
-        opts_spec => ['<>' => optspec(handler => sub{}, required => 1)],
+        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
         argv => [qw//],
         dies => 1,
     );
@@ -185,7 +185,7 @@ TODO: {
     my $opts = {};
     test_getoptions(
         name => 'optspec: required (on <>, set)',
-        opts_spec => ['<>' => optspec(handler => sub{}, required => 1)],
+        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
         argv => [qw/a b/],
         opts => $opts,
         expected_opts => {},
@@ -195,7 +195,7 @@ TODO: {
 {
     my $opts = {};
     test_getoptions(
-        name => 'optspec: required (on <>, set, but no handler, no arguments) -> dies',
+        name => 'optspec: required (on <>, set, but no destination, no arguments) -> dies',
         opts_spec => ['<>' => optspec(required => 1)],
         argv => [qw//],
         opts => $opts,
@@ -205,7 +205,7 @@ TODO: {
 {
     my $opts = {};
     test_getoptions(
-        name => 'optspec: required (on <>, set, but no handler, has arguments) -> ok',
+        name => 'optspec: required (on <>, set, but no destination, has arguments) -> ok',
         opts_spec => ['<>' => optspec(required => 1)],
         argv => [qw/a b/],
         opts => $opts,
@@ -248,9 +248,9 @@ TODO: {
     test_getoptions(
         name => 'optspec: mixed implict/explicit linkage',
         opts_spec =>  [
-          'foo=s', optspec(handler => \$opts->{foo} ),
+          'foo=s', optspec(destination => \$opts->{foo} ),
           'bar=s',
-          'baz=s', optspec(handler => \$opts->{baz} ),
+          'baz=s', optspec(destination => \$opts->{baz} ),
           'gaz=s', \$opts->{gaz},
         ],
         argv => [qw/--foo boo --baz boz --gaz gez/],
@@ -265,7 +265,7 @@ TODO: {
         name => 'optspec: with "hash-storage"',
         opts_spec => [
           $opts,
-          'foo=s', optspec(handler => \$opts->{foo} ),
+          'foo=s', optspec(destination => \$opts->{foo} ),
           'bar=s',
         ],
         argv => [qw/--foo boo --bar bur/],
@@ -280,9 +280,9 @@ TODO: {
         name => 'optspec: mixed implict/explicit linkage (with "hash-storage")',
         opts_spec => [
           $opts,
-          'foo=s', optspec(handler => \$opts->{foo} ),
+          'foo=s', optspec(destination => \$opts->{foo} ),
           'bar=s',
-          'baz=s', optspec(handler => \$opts->{baz} ),
+          'baz=s', optspec(destination => \$opts->{baz} ),
           'gaz=s', \$opts->{gaz},
         ],
         argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
@@ -294,12 +294,12 @@ TODO: {
 {
     my $opts = {};
     test_getoptions(
-        name => 'optspec: evaporates when it has no handler (in hash-storage mode)',
+        name => 'optspec: evaporates when it has no destination (in hash-storage mode)',
         opts_spec => [
           $opts,
           'foo=s', optspec(),
           'bar=s',
-          'baz=s', optspec(handler => \$opts->{baz} ),
+          'baz=s', optspec(destination => \$opts->{baz} ),
           'gaz=s', \$opts->{gaz},
         ],
         argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
@@ -344,11 +344,11 @@ TODO: {
 {   our ($opt_foo, $opt_bar);
     my $opts = {};
     test_getoptions(
-        name => "optspec: evaporates when it has no handler in 'classic mode' with 'legacy default desinations'" ,
+        name => "optspec: evaporates when it has no destination in 'classic mode' with 'legacy default desinations'" ,
         opts_spec => [
           'foo=s', optspec(),
           'bar=s',
-          'baz=s', optspec(handler => \$opts->{baz} ),
+          'baz=s', optspec(destination => \$opts->{baz} ),
           'gaz=s', \$opts->{gaz},
         ],
         argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
@@ -358,8 +358,8 @@ TODO: {
     );
     TODO: {
       # DONE: Now passes, suggesting #9 is resolved.
-      is($opt_foo // "[undef]" => 'boo', "optspec: [evaporation][without a handler][in classic mode][legacy default destination][1]");
-      is($opt_bar // "[undef]" => 'bur', "optspec: [evaporation][without a handler][in classic mode][legacy default destination][2]");
+      is($opt_foo // "[undef]" => 'boo', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][1]");
+      is($opt_bar // "[undef]" => 'bur', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][2]");
     }
 }
 


### PR DESCRIPTION
Hi @Perlancar,

As promised, here's a PR that is solely concentrated on #21 (`handler` => `destination`).

The PR contains 6 commits, described below, so as to ease cherry picking, if desired.

**The last state reflects what I propose.**

This small change does bring 2 new dependencies though... 

  - `require Carp;`        - RunTime, but only _"required"_ as needed.
  - `use Test::Warn; `   - For the test suite

Both of those are easy be remove at this time, if we want to. 
But they would probably come in handy later on, given the direction where things are headed.

Cheers,
Tabulo[n]?

*******

## The GORY DETAILS

### General REMARKS

#### The term `handler` practically dissapeared from sources 

  - With this change, most occurences of the term `handler` simply dissapear from the source code.
  - Where it remains, apart from the deprecation handling and notices, are some of the previous variable names that actually  do refer to `CODE` (e.g. `$arg_handler_*`).

#### The  `map_args()` function

You will notice addition of a utility package [Getopt::Long::More::Util] in the code; which currently contains a new little function `map_args()` which is employed for handling property **deprecations **and **aliases**. 

I have done it in this way because it's a bit more generic, and also because I already had the bulk of it somewhere :-).  

If desired, the body of `map_args()`  can easily be incoporated into `::OptSpec::new()`, or rewritten for just `handler`; but something tells me that we'll have to cater for synonyms of other stuff later on, if we ever wish to support easy migration from the many existing and disparate modules.

That being said, `map_args()` approach does carry a cost tag of a function call, though.

### The COMMITS, explained

#### Changes BEFORE adding NEW TESTS

  1. 57e35fd: Implement #21: handler -> destination
      - The **actual changes to code and docs** for implementing #21.
      - No new tests. 
      - Existing tests still pass, but some cause deprecation warnings for `handler`, as expected.

  2. 9ece031: Implement #21: handler->destination + adjust tests
     -  ++  Adjust previously existing tests so that they use `destination` instead of `handler`.
         => Existing tests continue to pass; and this time without any warnings are triggered by the tests themselves.
      - Still, no new tests.

  3. de9b0b1: Implement #21: handler->destination + adjust tests + readjust docs
      ++ A few improvements to the docs (mainly concerning `destination`)

####  The NEW TESTS

The last three commits are mere **variations** of the same thing; i.e. adding a **couple of tests** to ensure that the _**deprecation**_ itself is properly handled and **warned** about.

The essence is best captured in the last version, which goes as follows:

````perl
subtest "optspec: 'handler' is deprecated -> lives, but warns" => sub {
    warnings_exist {
      lives_ok { optspec( handler => sub { } ) }
    }
    [qr/\Whandler\W.*deprecated/],
    "optspec: 'handler' is deprecated -> warns";
};

subtest "optspec: Illegal to provide both 'destination' and its deprecated alias 'handler' -> dies" => sub {
    local *STDERR = \*STDOUT; # supress the depecation warning before 'die' => Just prettier test output.
    dies_ok { optspec(destination => sub {}, handler => sub {} ) };
};
````


  4. c6c76b2: Add tests specific to the deprecation of "handler"
     - **Hand crafted** version of the above tests

  5. 58b3590: Use Test::Warnings for some recent tests
    - Same thing with `use [Test::Warnings]`, hence  **shorter** and **prettier**, 

  6. cfbbf3e:  Use Test::Warn for some recent tests
    - Same thing with `use [Test::Warn]`; even  **shorter** and **prettier**,  
 
