### PR TITLE
Rename <GLM>::Util to avoid a conflict with existing package on CPAN

### DIFF
--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -367,9 +367,10 @@ sub OptionsPod {
 }
 
 package # hide from PAUSE indexer
-    Getopt::Long::More::Util;
+    Getopt::Long::More::Internal::Util;
 
-our @CARP_NOT = qw( Getopt::Long::More Getopt::Long::More::Util  Getopt::Long::More::OptSpec);
+# TAU: Named this <GLM>::Internal::Util because <GLM>::Util was already taken on CPAN.
+our @CARP_NOT = qw( Getopt::Long::More Getopt::Long::More::Internal::Util  Getopt::Long::More::OptSpec);
 
 # The subroutines here (::Util) are intended to be pretty generic
 # and so could also be used elsewhere later on.
@@ -415,7 +416,7 @@ package # hide from PAUSE indexer
     Getopt::Long::More::OptSpec;
 
 # Poor man's import....
-*map_args = \&Getopt::Long::More::Util::map_args;
+*map_args = \&Getopt::Long::More::Internal::Util::map_args;
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
Hi Perlancar,

Hope you are doing well... in the midst of all this... 

Noticed the contents of PR #21 (handler --> destination) did not make it to the latest release of GLM (v.006). 

That's probably because the internal ::Util package introduced a name conflict with an existing module on CPAN <Getopt::Long::More::Util>. 

Here's a little PR that aims to resolve the issue by simply renaming the internal package to <Getopt::Long::More::Internal::Util>.

I hope this is sufficient for having PR #21 appear in the release. Let me know if there were other issues/reservations with it.

BTW, I also hope this sort of sporadic contributions (more than a year apart) are not too annoying... If you wish, we can discuss via private email to find a more convenient way (also considering your previous proposal, but perhaps in a slightly different way).

Best,
Tabulon

