### PR TITLE
Tau.feat 2021.improve gol compat

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,4 @@
-version = 0.007
+version = 0.005
 
 name    = Getopt-Long-More
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,4 @@
-version = 0.005
+version = 0.007
 
 name    = Getopt-Long-More
 

--- a/lib/Getopt/Long/More.pm
+++ b/lib/Getopt/Long/More.pm
@@ -14,7 +14,7 @@ our @EXPORT_OK = qw(HelpMessage VersionMessage Configure
                     GetOptionsFromArray GetOptionsFromString
                     OptionsPod);
 
-
+# Public API @ [GLM / OptSpec ]
 sub optspec {
     Getopt::Long::More::OptSpec->new(@_);
 }
@@ -24,6 +24,7 @@ sub OptSpec {
     Getopt::Long::More::OptSpec->new(@_);
 }
 
+# Public API @ [GOL]
 sub import {
     require Getopt::Long;
     goto &Getopt::Long::import;
@@ -379,7 +380,7 @@ sub OptionsPod {
 }
 
 package Getopt::Long::More::Parser;
-
+use Getopt::Long;
 our @ISA=(qw/Getopt::Long::Parser/);
 
 # copied verbatim from Getopt::Long (except for the assignment of '$Getopt::Long::caller')


### PR DESCRIPTION
This PR paves the way for an upcoming change that will incorporate the GoL's own test-suite directly within the GLM repo. 

The changes proposed herein enable GLM to pass the GoL test suite, without breaking the current GLM tests. Here are those changes:

  - 1) GLM's _functional_ **public interface** is now hardly distingishable from GoL's; with the addition of `import()` and and even the _deprecated_ `config()` routine;

  - 2) GLM now also supports GOL's **OO interface** via <`Getopt::Long::More::Parser`> which is a subclass of <`Getopt::Long::Parser`>. 

  - 3) Also included is a quick fix for an already **lurking bug** related to the way we were setting `$GoL::caller` that prevented the _classic_ mode (with automatic  `opt_*` destinations in `calller`s package ) from correctly working in some cases; 

       This should now be fixed, although the way it ended up is probably a bit ugly (e.g. `||=` is probably superflous), but appears to work fine, even with GOL's own test suite.

--- 

Notice that this PR doesn't introduce any new tests, but merely contends itself by passing GLM's existing test suite. In any case, GOL's test-suite will get incorporated by the next couple PR's.

---

As a side note, it's such a pity that we keep bringing over almost verbatim copies of GOL's code,  because GOL lacks practical override mechanisms... 

Not that I am complaining, either. GOL's job is (and has been) a tough one... trying to keep backwards compatibility over so many years... exposing an OO interface over functional code (with global configuration that can't be ditched because counted upon)... etc... etc...

I just hope we end up finding a way, as you mentioned in an earlier post, by either proposing (to GOL): 

   - a) individual patches 
   - b) **extensibility** features (which make it easier to extend/override GOL itself, so that we won't need to propose too many individual patches)

or else, we may have to fork in the end.