### PR TITLE
Reorganize test suite as described in gh [#08]

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,11 +2,15 @@
 
 use strict;
 use warnings;
-use Test::Exception;
-use Test::Warn;
+
 use Test::More 0.98;
 
-use Getopt::Long::More qw(optspec);
+BEGIN { # so that we can : use TestHelperGLM;
+    use File::Basename; 
+    use lib (dirname(__FILE__) || "./t" ) . "/lib"; 
+}
+use Getopt::Long::More;
+use TestHelperGLM qw(test_getoptions);
 
 # XXX test exports
 
@@ -35,7 +39,6 @@ use Getopt::Long::More qw(optspec);
         expected_argv => [qw/a b/],
     );
 }
-
 {
     my $opts = {};
     test_getoptions(
@@ -48,7 +51,6 @@ use Getopt::Long::More qw(optspec);
         expected_argv => [qw/--help a b/],
     );
 }
-
 {
     my $opts = {};
     test_getoptions(
@@ -60,178 +62,6 @@ use Getopt::Long::More qw(optspec);
         expected_argv => [qw//],
     );
 }
-
-subtest "optspec: no property is required" => sub {
-    lives_ok { optspec() };
-};
-
-subtest "optspec: unknown property -> dies" => sub {
-    dies_ok { optspec(foo=>1) };
-};
-
-
-subtest "optspec: 'handler' is deprecated -> lives, but warns" => sub {
-    warnings_exist {
-      lives_ok { optspec( handler => sub { } ) }
-    }
-    [qr/\Whandler\W.*deprecated/],
-    "optspec: 'handler' is deprecated -> warns";
-};
-
-subtest "optspec: Illegal to provide both 'destination' and its deprecated alias 'handler' -> dies" => sub {
-    local *STDERR = \*STDOUT; # supress the depecation warning before 'die' => Just prettier test output.
-    dies_ok { optspec(destination => sub {}, handler => sub {} ) };
-};
-
-
-subtest "optspec: extra properties allowed" => sub {
-    lives_ok { optspec(destination=>sub{}, _foo=>1, 'x.bar'=>2, _=>{baz=>3}, x=>{qux=>4}) };
-};
-
-subtest "optspec: invalid extra properties -> dies" => sub {
-    dies_ok { optspec(destination=>sub{}, 'x.'=>1) };
-};
-
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: default (unset)',
-        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
-        argv => [qw//],
-        opts => $opts,
-        expected_opts => {foo => "bar"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: default (set)',
-        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
-        argv => [qw/--foo qux/],
-        opts => $opts,
-        expected_opts => {foo => "qux"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: default (set, but no destination) -> dies',
-        opts_spec => ['foo=s' => optspec(default => "bar")],
-        argv => [qw/--foo qux/],
-        opts => $opts,
-        dies => 1,
-    );
-}
-TODO: {
-    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: default (set, but no destination) -> dies',
-        opts_spec => [$opts, 'foo=s' => optspec(default => "bar")],
-        argv => [qw/--foo qux/],
-        opts => $opts,
-        expected_opts => {foo => "qux"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: default (on <> -> ignored)',
-        opts_spec => ['<>' => optspec(destination => sub{}, default => ["a","b"])],
-        argv => [qw//],
-        opts => $opts,
-        expected_opts => {},
-        expected_argv => [qw//],
-    );
-}
-
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (unset)',
-        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
-        argv => [qw//],
-        dies => 1,
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (set)',
-        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
-        argv => [qw/--foo=bar/],
-        opts => $opts,
-        expected_opts => {foo => "bar"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (set, but no destination) -> dies',
-        opts_spec => ['foo=s' => optspec(required => 1)],
-        argv => [qw/--foo qux/],
-        opts => $opts,
-        dies => 1,
-    );
-}
-TODO: {
-    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (set, but no destination) -> dies',
-        opts_spec => [$opts, 'foo=s' => optspec(required => 1)],
-        argv => [qw/--foo qux/],
-        opts => $opts,
-        expected_opts => {foo => "qux"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (on <>, unset)',
-        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
-        argv => [qw//],
-        dies => 1,
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (on <>, set)',
-        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
-        argv => [qw/a b/],
-        opts => $opts,
-        expected_opts => {},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (on <>, set, but no destination, no arguments) -> dies',
-        opts_spec => ['<>' => optspec(required => 1)],
-        argv => [qw//],
-        opts => $opts,
-        dies => 1,
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: required (on <>, set, but no destination, has arguments) -> ok',
-        opts_spec => ['<>' => optspec(required => 1)],
-        argv => [qw/a b/],
-        opts => $opts,
-        expected_opts => {},
-        expected_argv => [qw/a b/],
-    );
-}
-
 {
     my $opts = {};
     test_getoptions(
@@ -243,7 +73,6 @@ TODO: {
         expected_argv => [qw//],
     );
 }
-
 {
     my $opts = {};
     test_getoptions(
@@ -257,72 +86,6 @@ TODO: {
         argv => [qw/--foo boo --baz boz --gaz gez/],
         opts => $opts,
         expected_opts => {foo => "boo", baz => "boz", gaz => "gez"},
-        expected_argv => [qw//],
-    );
-}
-
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: mixed implict/explicit linkage',
-        opts_spec =>  [
-          'foo=s', optspec(destination => \$opts->{foo} ),
-          'bar=s',
-          'baz=s', optspec(destination => \$opts->{baz} ),
-          'gaz=s', \$opts->{gaz},
-        ],
-        argv => [qw/--foo boo --baz boz --gaz gez/],
-        opts => $opts,
-        expected_opts => {foo => "boo", baz => "boz", gaz => "gez"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: with "hash-storage"',
-        opts_spec => [
-          $opts,
-          'foo=s', optspec(destination => \$opts->{foo} ),
-          'bar=s',
-        ],
-        argv => [qw/--foo boo --bar bur/],
-        opts => $opts,
-        expected_opts => {foo => "boo", bar => "bur"},
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: mixed implict/explicit linkage (with "hash-storage")',
-        opts_spec => [
-          $opts,
-          'foo=s', optspec(destination => \$opts->{foo} ),
-          'bar=s',
-          'baz=s', optspec(destination => \$opts->{baz} ),
-          'gaz=s', \$opts->{gaz},
-        ],
-        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
-        opts => $opts,
-        expected_opts => {foo => "boo", bar => "bur", baz => "boz", gaz => "gez" },
-        expected_argv => [qw//],
-    );
-}
-{
-    my $opts = {};
-    test_getoptions(
-        name => 'optspec: evaporates when it has no destination (in hash-storage mode)',
-        opts_spec => [
-          $opts,
-          'foo=s', optspec(),
-          'bar=s',
-          'baz=s', optspec(destination => \$opts->{baz} ),
-          'gaz=s', \$opts->{gaz},
-        ],
-        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
-        opts => $opts,
-        expected_opts => {foo => "boo", bar => "bur", baz => "boz", gaz => "gez" },
         expected_argv => [qw//],
     );
 }
@@ -356,28 +119,7 @@ TODO: {
     );
     {
       # DONE: Now passes, suggesting #9 is resolved.
-      is($opt_foo // "[undef]" => 'boo', "legacy: default destinations' work as expected" );
-    }
-}
-{   our ($opt_foo, $opt_bar);
-    my $opts = {};
-    test_getoptions(
-        name => "optspec: evaporates when it has no destination in 'classic mode' with 'legacy default desinations'" ,
-        opts_spec => [
-          'foo=s', optspec(),
-          'bar=s',
-          'baz=s', optspec(destination => \$opts->{baz} ),
-          'gaz=s', \$opts->{gaz},
-        ],
-        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
-        opts => $opts,
-        expected_opts => { baz => "boz", gaz => "gez" },
-        expected_argv => [qw//],
-    );
-    {
-      # DONE: These now pass, suggesting #9 is resolved.
-      is($opt_foo // "[undef]" => 'boo', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][1]");
-      is($opt_bar // "[undef]" => 'bur', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][2]");
+      is($opt_foo // "[undef]" => 'boo', "legacy: default destinations work as expected" );
     }
 }
 
@@ -386,50 +128,4 @@ TODO: {
 
 done_testing;
 
-sub test_getoptions {
-    my %args = @_;
-    my @argv = @{ $args{argv} };
-    subtest +($args{name} // join(" ", @argv)) => sub {
-        my $old_conf;
-        $old_conf = Getopt::Long::More::Configure(@{$args{config}})
-            if $args{config};
-        my $res;
-        eval {
-            $res = Getopt::Long::More::GetOptionsFromArray(
-                \@argv,
-                @{ $args{opts_spec} },
-            );
-        };
-        my $err = $@;
 
-        {
-            if ($args{dies}) {
-                ok($err, "dies");
-                last;
-            } else {
-                ok(!$err, "doesn't die") or do {
-                    diag "err=$err";
-                    last;
-                };
-            }
-            if ($args{is_success} // 1) {
-                ok($res, "success");
-            } else {
-                ok(!$res, "fail");
-            }
-            if ($args{expected_opts}) {
-                is_deeply($args{opts}, $args{expected_opts}, "options")
-                    or diag explain $args{opts};
-            }
-            if ($args{expected_argv}) {
-                is_deeply(\@argv, $args{expected_argv}, "remaining argv")
-                    or diag explain \@argv;
-            }
-            if ($args{posttest}) {
-                $args{posttest}->();
-            }
-        }
-
-        Getopt::Long::More::Configure($old_conf) if $old_conf;
-    };
-}

--- a/t/02-optspec.t
+++ b/t/02-optspec.t
@@ -1,0 +1,280 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::Warn;
+use Test::More 0.98;
+
+BEGIN { # so that we can : use TestHelperGLM;
+    use File::Basename; 
+    use lib (dirname(__FILE__) || "./t" ) . "/lib"; 
+}
+
+use Getopt::Long::More qw(optspec);
+use TestHelperGLM qw(test_getoptions);
+
+# XXX test exports
+
+subtest "optspec: no property is required" => sub {
+    lives_ok { optspec() };
+};
+
+subtest "optspec: unknown property -> dies" => sub {
+    dies_ok { optspec(foo=>1) };
+};
+
+subtest "optspec: 'handler' is deprecated -> lives, but warns" => sub {
+    warnings_exist {
+      lives_ok { optspec( handler => sub { } ) }
+    }
+    [qr/\Whandler\W.*deprecated/],
+    "optspec: 'handler' is deprecated -> warns";
+};
+
+subtest "optspec: Illegal to provide both 'destination' and its deprecated alias 'handler' -> dies" => sub {
+    local *STDERR = \*STDOUT; # supress the depecation warning before 'die' => Just prettier test output.
+    dies_ok { optspec(destination => sub {}, handler => sub {} ) };
+};
+
+subtest "optspec: extra properties allowed" => sub {
+    lives_ok { optspec(destination=>sub{}, _foo=>1, 'x.bar'=>2, _=>{baz=>3}, x=>{qux=>4}) };
+};
+
+subtest "optspec: invalid extra properties -> dies" => sub {
+    dies_ok { optspec(destination=>sub{}, 'x.'=>1) };
+};
+
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: default (unset)',
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
+        argv => [qw//],
+        opts => $opts,
+        expected_opts => {foo => "bar"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: default (set)',
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, default => "bar")],
+        argv => [qw/--foo qux/],
+        opts => $opts,
+        expected_opts => {foo => "qux"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: default (set, but no destination) -> dies',
+        opts_spec => ['foo=s' => optspec(default => "bar")],
+        argv => [qw/--foo qux/],
+        opts => $opts,
+        dies => 1,
+    );
+}
+TODO: {
+    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: default (set, but no destination) -> dies',
+        opts_spec => [$opts, 'foo=s' => optspec(default => "bar")],
+        argv => [qw/--foo qux/],
+        opts => $opts,
+        expected_opts => {foo => "qux"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: default (on <> -> ignored)',
+        opts_spec => ['<>' => optspec(destination => sub{}, default => ["a","b"])],
+        argv => [qw//],
+        opts => $opts,
+        expected_opts => {},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (unset)',
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
+        argv => [qw//],
+        dies => 1,
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (set)',
+        opts_spec => ['foo=s' => optspec(destination => \$opts->{foo}, required => 1)],
+        argv => [qw/--foo=bar/],
+        opts => $opts,
+        expected_opts => {foo => "bar"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (set, but no destination) -> dies',
+        opts_spec => ['foo=s' => optspec(required => 1)],
+        argv => [qw/--foo qux/],
+        opts => $opts,
+        dies => 1,
+    );
+}
+TODO: {
+    local $TODO = "currently dies, but we shouldn't require destination when in hash-storage mode";
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (set, but no destination) -> dies',
+        opts_spec => [$opts, 'foo=s' => optspec(required => 1)],
+        argv => [qw/--foo qux/],
+        opts => $opts,
+        expected_opts => {foo => "qux"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (on <>, unset)',
+        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
+        argv => [qw//],
+        dies => 1,
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (on <>, set)',
+        opts_spec => ['<>' => optspec(destination => sub{}, required => 1)],
+        argv => [qw/a b/],
+        opts => $opts,
+        expected_opts => {},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (on <>, set, but no destination, no arguments) -> dies',
+        opts_spec => ['<>' => optspec(required => 1)],
+        argv => [qw//],
+        opts => $opts,
+        dies => 1,
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: required (on <>, set, but no destination, has arguments) -> ok',
+        opts_spec => ['<>' => optspec(required => 1)],
+        argv => [qw/a b/],
+        opts => $opts,
+        expected_opts => {},
+        expected_argv => [qw/a b/],
+    );
+}
+
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: mixed implict/explicit linkage',
+        opts_spec =>  [
+          'foo=s', optspec(destination => \$opts->{foo} ),
+          'bar=s',
+          'baz=s', optspec(destination => \$opts->{baz} ),
+          'gaz=s', \$opts->{gaz},
+        ],
+        argv => [qw/--foo boo --baz boz --gaz gez/],
+        opts => $opts,
+        expected_opts => {foo => "boo", baz => "boz", gaz => "gez"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: with "hash-storage"',
+        opts_spec => [
+          $opts,
+          'foo=s', optspec(destination => \$opts->{foo} ),
+          'bar=s',
+        ],
+        argv => [qw/--foo boo --bar bur/],
+        opts => $opts,
+        expected_opts => {foo => "boo", bar => "bur"},
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: mixed implict/explicit linkage (with "hash-storage")',
+        opts_spec => [
+          $opts,
+          'foo=s', optspec(destination => \$opts->{foo} ),
+          'bar=s',
+          'baz=s', optspec(destination => \$opts->{baz} ),
+          'gaz=s', \$opts->{gaz},
+        ],
+        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
+        opts => $opts,
+        expected_opts => {foo => "boo", bar => "bur", baz => "boz", gaz => "gez" },
+        expected_argv => [qw//],
+    );
+}
+{
+    my $opts = {};
+    test_getoptions(
+        name => 'optspec: evaporates when it has no destination (in hash-storage mode)',
+        opts_spec => [
+          $opts,
+          'foo=s', optspec(),
+          'bar=s',
+          'baz=s', optspec(destination => \$opts->{baz} ),
+          'gaz=s', \$opts->{gaz},
+        ],
+        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
+        opts => $opts,
+        expected_opts => {foo => "boo", bar => "bur", baz => "boz", gaz => "gez" },
+        expected_argv => [qw//],
+    );
+}
+{   our ($opt_foo, $opt_bar);
+    my $opts = {};
+    test_getoptions(
+        name => "optspec: evaporates when it has no destination in 'classic mode' with 'legacy default desinations'" ,
+        opts_spec => [
+          'foo=s', optspec(),
+          'bar=s',
+          'baz=s', optspec(destination => \$opts->{baz} ),
+          'gaz=s', \$opts->{gaz},
+        ],
+        argv => [qw/--foo boo --bar bur --baz boz --gaz gez/],
+        opts => $opts,
+        expected_opts => { baz => "boz", gaz => "gez" },
+        expected_argv => [qw//],
+    );
+    {
+      # DONE: These now pass, suggesting #9 is resolved.
+      is($opt_foo // "[undef]" => 'boo', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][1]");
+      is($opt_bar // "[undef]" => 'bur', "optspec: [evaporation][without a destination][in classic mode][legacy default destination][2]");
+    }
+}
+
+# XXX test summary
+# XXX test pod
+
+done_testing;
+
+

--- a/t/lib/TestHelperGLM.pm
+++ b/t/lib/TestHelperGLM.pm
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+
+package TestHelperGLM;
+ 
+use Carp;
+use Test::More 0.98;
+
+use Exporter;
+our @ISA    = qw/Exporter/;
+our @EXPORT_OK = qw(
+  test_getoptions
+);
+ 
+# PUBLIC (outer) routine; responsable for "caller" and "TODO" tricekery
+sub test_getoptions {
+    my $caller = (caller)[0];
+
+    # For TODO tests, [Test::More] needs (in the current package) : 
+    #   * a `TODO:` (label) as well as a `$TODO` (variable)  
+    local $TODO = do { no strict qw/refs/; ${ $caller . '::TODO' } };
+    return _test_getoptions(caller=>$caller, @_) unless (defined($TODO));
+TODO:    { _test_getoptions(caller=>$caller, @_) } 
+}
+
+# PRIVATE (inner) routine. 
+sub _test_getoptions {
+    my %args = @_;
+    my @argv = @{ $args{argv} };
+
+    subtest +($args{name} // join(" ", @argv)) => sub {
+
+        my $old_conf;
+        $old_conf = Getopt::Long::More::Configure(@{$args{config}})
+            if $args{config};
+
+        # This is needed for testing 'legacy' destinations ($opt_XXX) which get created caller's package; 
+        # i.e. whatever GoL happens to percieve as its 'caller'.
+        local $Getopt::Long::caller ||= $args{caller} unless defined($Getopt::Long::caller);
+
+        my $res;
+        eval {
+            $res = Getopt::Long::More::GetOptionsFromArray(
+                \@argv,
+                @{ $args{opts_spec} },
+            );
+        };
+        my $err = $@;
+
+        {
+            if ($args{dies}) {
+                ok($err, "dies");
+                last;
+            } else {
+                ok(!$err, "doesn't die") or do {
+                    diag "err=$err";
+                    last;
+                };
+            }
+            if ($args{is_success} // 1) {
+                ok($res, "success");
+            } else {
+                ok(!$res, "fail");
+            }
+            if ($args{expected_opts}) {
+                is_deeply($args{opts}, $args{expected_opts}, "options")
+                    or diag explain $args{opts};
+            }
+            if ($args{expected_argv}) {
+                is_deeply(\@argv, $args{expected_argv}, "remaining argv")
+                    or diag explain \@argv;
+            }
+            if ($args{posttest}) {
+                $args{posttest}->();
+            }
+        }
+
+        Getopt::Long::More::Configure($old_conf) if $old_conf;
+    };
+}
+
+1;
+
+# ABSTRACT: Things that are common to many GLM tests
+
+


### PR DESCRIPTION
# SYNOPSIS:

Reorganize test suite as described in gh [#08]

# The WHY:

Before and during the refactoring (#11) and the development of more features, it is useful to beef up the testing, which was also part of the motivation for (#26). 

Since we have recently visited the "test-suite", I just took the opportunity to go ahead and impement #8, which will ease adding more tests, both technically and also by reducing our own mental barriers... :-)

# The WHAT:

Implement #8, resulting in a split of tests between:

  - `t/01-basic.t` : anything "basic" that doesn't involve optspec(); 

     In this part, we are mostly trying to make sure that GLM has basic sane behavior which is identical with GL, fulfilling the doc's promise of being a "drop-in replacement".

  - `t/02-optspec.t` : This second part is anything that involves optspec(), while still not drawing on GLM's own fatures; 

This exercise also gave birth to a little **test helper module** `t/lib/TestHelperGLM.pm` which will be providing the common stuff needed by the test suite (which currently includes the `test_getoptions()` routine). 

# The FUTURE:

Later on, we can add some other tests for ensuring that GLM is functioning correctly with regard to its **own advertised features**, such as:

  - `t/xx-opt-version.t`
  - `t/xx-opt-helptext.t`      # hold on to this one until the functionaly matures a little 
  - `t/xx-completion.t`       # idem. How do you test **completion** anyways?



